### PR TITLE
Feature/EV-216 tag unique error

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1,7 +1,7 @@
 # Learn more about services, parameters and containers at
 # https://symfony.com/doc/current/service_container.html
 parameters:
-    # parameter_name: value
+# parameter_name: value
 
 services:
     value_converter:
@@ -207,17 +207,14 @@ services:
     tag_normalizer:
         class: AdminBundle\Service\TagNormalizer
         arguments:
-            - '@service_container'
-            -
-                services:
-                    tag_manager: tag_manager
-                    unknown_tag_manager: unknown_tag_manager
+            - '@doctrine.orm.entity_manager'
 
     tag_manager:
         public: true
         class: AdminBundle\Service\TagManager
         calls:
             - [setTagNormalizer, ['@tag_normalizer']]
+            - [setUnknownTagManager, ['@unknown_tag_manager']]
         arguments:
             - '@doctrine.orm.entity_manager'
             - '%fpn_tag.entity.tag.class%'

--- a/features/events.tags.feature
+++ b/features/events.tags.feature
@@ -65,7 +65,7 @@ Feature: Events
     {
       "name": "Another tagged event",
       "tags": [ "banana", "CITRUS" ],
-      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2001-01-01" } ]
+      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2000-01-02" } ]
     }
     """
     Then the response status code should be 201
@@ -83,7 +83,7 @@ Feature: Events
     {
       "name": "A tagged event",
       "tags": [ "æble" ],
-      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2001-01-01" } ]
+      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2000-01-02" } ]
     }
     """
     Then the response status code should be 201
@@ -98,7 +98,7 @@ Feature: Events
     {
       "name": "A tagged event",
       "tags": [ "æble", "banan" ],
-      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2001-01-01" } ]
+      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2000-01-02" } ]
     }
     """
     Then the response status code should be 201
@@ -114,7 +114,7 @@ Feature: Events
     {
       "name": "A tagged event",
       "tags": [ "æble", "apple" ],
-      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2001-01-01" } ]
+      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2000-01-02" } ]
     }
     """
     Then the response status code should be 201
@@ -130,7 +130,7 @@ Feature: Events
     {
       "name": "A tagged event",
       "tags": [ ],
-      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2001-01-01" } ]
+      "occurrences": [ { "startDate": "2000-01-01", "endDate": "2000-01-02" } ]
     }
     """
     Then the response status code should be 201

--- a/features/events.tags.feature
+++ b/features/events.tags.feature
@@ -5,7 +5,7 @@ Feature: Events
 
   Background:
     Given the following users exist:
-      | username   | password | roles          |
+      | username   | password | roles      |
       | api-read   | apipass  | ROLE_API_READ  |
       | api-write  | apipass  | ROLE_API_WRITE |
       | api-write2 | apipass  | ROLE_API_WRITE |
@@ -15,6 +15,7 @@ Feature: Events
       | apple  |
       | banana |
       | citrus |
+      | café   |
 
     And the following tags are unknown:
       | name   | tag    |
@@ -27,13 +28,15 @@ Feature: Events
     When I add "Accept" header equal to "application/ld+json"
     And I send a "GET" request to "/api/tags"
     Then the response status code should be 200
-    And the JSON node "hydra:member" should have 3 elements
+    And the JSON node "hydra:member" should have 4 elements
     And the JSON node "hydra:member[0].@id" should be equal to "/api/tags/1"
     And the JSON node "hydra:member[0].name" should be equal to "apple"
     And the JSON node "hydra:member[1].@id" should be equal to "/api/tags/2"
     And the JSON node "hydra:member[1].name" should be equal to "banana"
     And the JSON node "hydra:member[2].@id" should be equal to "/api/tags/3"
     And the JSON node "hydra:member[2].name" should be equal to "citrus"
+    And the JSON node "hydra:member[3].@id" should be equal to "/api/tags/4"
+    And the JSON node "hydra:member[3].name" should be equal to "cafe"
 
   Scenario: Events with tags
     When I authenticate as "api-write"
@@ -43,15 +46,16 @@ Feature: Events
     """
     {
       "name": "A tagged event",
-      "tags": [ "apple", "Banana" ],
+      "tags": [ "apple", "Banana", "café" ],
       "occurrences": [ { "startDate": "2000-01-01", "endDate": "2001-01-01" } ]
     }
     """
     Then the response status code should be 201
     And the JSON node "name" should be equal to "A tagged event"
-    And the JSON node "tags" should have 2 elements
+    And the JSON node "tags" should have 3 elements
     And the JSON node "tags[0]" should be equal to "apple"
     And the JSON node "tags[1]" should be equal to "banana"
+    And the JSON node "tags[2]" should be equal to "cafe"
 
     When I authenticate as "api-write"
     And I add "Content-Type" header equal to "application/ld+json"
@@ -138,9 +142,10 @@ Feature: Events
     Then the response status code should be 200
     And the header "Content-Type" should be equal to "application/ld+json; charset=utf-8"
     And the JSON node "@id" should be equal to "/api/events/1"
-    And the JSON node "tags" should have 2 elements
+    And the JSON node "tags" should have 3 elements
     And the JSON node "tags[0]" should be equal to "apple"
     And the JSON node "tags[1]" should be equal to "banana"
+    And the JSON node "tags[1]" should be equal to "cafe"
 
   Scenario: Filter by tags
     When I authenticate as "api-read"

--- a/features/events.tags.feature
+++ b/features/events.tags.feature
@@ -15,7 +15,7 @@ Feature: Events
       | apple  |
       | banana |
       | citrus |
-      | café   |
+      | cafe   |
 
     And the following tags are unknown:
       | name   | tag    |
@@ -145,7 +145,7 @@ Feature: Events
     And the JSON node "tags" should have 3 elements
     And the JSON node "tags[0]" should be equal to "apple"
     And the JSON node "tags[1]" should be equal to "banana"
-    And the JSON node "tags[1]" should be equal to "cafe"
+    And the JSON node "tags[2]" should be equal to "cafe"
 
   Scenario: Filter by tags
     When I authenticate as "api-read"

--- a/src/AdminBundle/Service/TagManager.php
+++ b/src/AdminBundle/Service/TagManager.php
@@ -11,6 +11,7 @@
 namespace AdminBundle\Service;
 
 use AppBundle\Entity\CustomTaggable;
+use AppBundle\Entity\UnknownTag;
 use Doctrine\DBAL\DBALException;
 use DoctrineExtensions\Taggable\Taggable;
 use FPN\TagBundle\Entity\TagManager as BaseTagManager;
@@ -38,9 +39,15 @@ class TagManager extends BaseTagManager
 
     /**
      * {@inheritdoc}
+     *
+     * @throws DBALException
      */
     public function loadOrCreateTags(array $names)
     {
+        if (!$names) {
+            return [];
+        }
+
         if ($this->tagNormalizer) {
             $names = $this->tagNormalizer->normalize($names, $this);
         }
@@ -48,8 +55,15 @@ class TagManager extends BaseTagManager
         // Remove falsy values
         $names = array_filter($names);
 
+        // If we have an 'unknownTagManager' injected we need to handle unknown tags,
+        // both the creation of unknown tags and 'translation' to a known tag.
         if ($this->unknownTagManager) {
-            $this->createUnknownTags($names);
+            // Create unknown tags
+            $unknownTags = $this->loadOrCreateUnknownTags($names);
+
+            // Translate unknown tags to their know counter parts
+            $validNames = $this->loadTagNames($names);
+            $names = $this->addTranslatedTagNames($validNames, ...$unknownTags);
         }
 
         return parent::loadOrCreateTags($names);
@@ -83,11 +97,7 @@ class TagManager extends BaseTagManager
             $builder->where($builder->expr()->in('t.name', $names));
         }
 
-        $tags = $builder
-            ->getQuery()
-            ->getResult();
-
-        return $tags;
+        return $builder->getQuery()->getResult();
     }
 
     public function createTag($name)
@@ -113,7 +123,7 @@ class TagManager extends BaseTagManager
     }
 
     /**
-     * Create all unknown tags.
+     * Load or create unknown tags from list of names.
      *
      * The EventDatabase has a concept og 'known' (i.e. official or approved) tags. If imported
      * events has tags that are not known they should be created as an 'UnknownTag'.
@@ -121,15 +131,19 @@ class TagManager extends BaseTagManager
      * @param array $names
      *   A normalized list of tag names
      *
+     * @return UnknownTag[]
+     *
      * @throws DBALException
      */
-    private function createUnknownTags(array $names): void
+    private function loadOrCreateUnknownTags(array $names): array
     {
+        $unknownTags = [];
+        $unknownTagNames = [];
+
         $conn = $this->em->getConnection();
-        $sql = 'SELECT EXISTS(SELECT * FROM tag WHERE name = :name) OR EXISTS(SELECT * FROM unknown_tag WHERE name = :name) as tagExists';
+        $sql = 'SELECT EXISTS(SELECT * FROM tag WHERE name = :name) as tagExists';
         $stmt = $conn->prepare($sql);
 
-        $unknownTagNames = [];
         foreach ($names as $name) {
             $stmt->execute(array('name' => $name));
             $result = $stmt->fetch();
@@ -140,7 +154,51 @@ class TagManager extends BaseTagManager
         }
 
         if (!empty($unknownTagNames)) {
-            $this->unknownTagManager->loadOrCreateTags($unknownTagNames);
+            $unknownTags = $this->unknownTagManager->loadOrCreateTags($unknownTagNames);
         }
+
+        return $unknownTags;
+    }
+
+    /**
+     * Add translated tag names to list of tag names.
+     *
+     * The EventDatabase has a concept og 'known' (i.e. official or approved) tags. Unknown tags
+     * can be mapped to these tags. If an unknown tag has been mapped to a known tag we need to
+     * add the name of the known tag to list of tag names.
+     *
+     * @param array $names
+     *   The list of tag names to add to
+     * @param UnknownTag ...$unknownTags
+     *   The unknown tags to check and add
+     *
+     * @return array
+     */
+    private function addTranslatedTagNames(array &$names, UnknownTag ...$unknownTags): array
+    {
+        foreach ($unknownTags as $unknownTag) {
+            $knownTag = $unknownTag->getTag();
+            if ($knownTag) {
+                $names[] = $knownTag->getName();
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Load list of valid tag names.
+     *
+     * @param array $names
+     *
+     * @return array
+     */
+    private function loadTagNames(array $names): array
+    {
+        $tags = $this->loadTags($names);
+
+        return array_map(function ($tag) {
+            return $tag->getName();
+        }, $tags);
     }
 }

--- a/src/AdminBundle/Service/TagManager.php
+++ b/src/AdminBundle/Service/TagManager.php
@@ -11,19 +11,29 @@
 namespace AdminBundle\Service;
 
 use AppBundle\Entity\CustomTaggable;
+use Doctrine\DBAL\DBALException;
 use DoctrineExtensions\Taggable\Taggable;
 use FPN\TagBundle\Entity\TagManager as BaseTagManager;
 
 class TagManager extends BaseTagManager
 {
-    /**
-     * @var TagNormalizerInterface
-     */
+    /** @var TagNormalizerInterface */
     private $tagNormalizer;
 
+    /** @var TagManager */
+    private $unknownTagManager;
+
+    /**
+     * @param TagNormalizerInterface|null $tagNormalizer
+     */
     public function setTagNormalizer(TagNormalizerInterface $tagNormalizer = null)
     {
         $this->tagNormalizer = $tagNormalizer;
+    }
+
+    public function setUnknownTagManager(TagManager $tagManager = null)
+    {
+        $this->unknownTagManager = $tagManager;
     }
 
     /**
@@ -34,7 +44,13 @@ class TagManager extends BaseTagManager
         if ($this->tagNormalizer) {
             $names = $this->tagNormalizer->normalize($names, $this);
         }
+
+        // Remove falsy values
         $names = array_filter($names);
+
+        if ($this->unknownTagManager) {
+            $this->createUnknownTags($names);
+        }
 
         return parent::loadOrCreateTags($names);
     }
@@ -94,5 +110,37 @@ class TagManager extends BaseTagManager
         $this->em->flush();
 
         return true;
+    }
+
+    /**
+     * Create all unknown tags.
+     *
+     * The EventDatabase has a concept og 'known' (i.e. official or approved) tags. If imported
+     * events has tags that are not known they should be created as an 'UnknownTag'.
+     *
+     * @param array $names
+     *   A normalized list of tag names
+     *
+     * @throws DBALException
+     */
+    private function createUnknownTags(array $names): void
+    {
+        $conn = $this->em->getConnection();
+        $sql = 'SELECT EXISTS(SELECT * FROM tag WHERE name = :name) OR EXISTS(SELECT * FROM unknown_tag WHERE name = :name) as tagExists';
+        $stmt = $conn->prepare($sql);
+
+        $unknownTagNames = [];
+        foreach ($names as $name) {
+            $stmt->execute(array('name' => $name));
+            $result = $stmt->fetch();
+
+            if ($result['tagExists'] === '0') {
+                $unknownTagNames[] = $name;
+            }
+        }
+
+        if (!empty($unknownTagNames)) {
+            $this->unknownTagManager->loadOrCreateTags($unknownTagNames);
+        }
     }
 }

--- a/src/AppBundle/Features/Context/FeatureContext.php
+++ b/src/AppBundle/Features/Context/FeatureContext.php
@@ -10,6 +10,7 @@
 
 namespace AppBundle\Features\Context;
 
+use AdminBundle\Service\TagManager;
 use AppBundle\Entity\Group;
 use AppBundle\Entity\User;
 use Behat\Behat\Context\Context;
@@ -177,8 +178,10 @@ class FeatureContext extends BaseContext implements Context, KernelAwareContext
      */
     public function theFollowingTagsExist(TableNode $table)
     {
+        /** @var TagManager $tagManager */
         $tagManager = $this->container->get('tag_manager');
         $tagManager->setTagNormalizer(null);
+        $tagManager->setUnknownTagManager(null);
         $names = array_map(function ($row) {
             return $row['name'];
         }, $table->getHash());

--- a/tests/AdminBundle/Service/FeedReaderTest.php
+++ b/tests/AdminBundle/Service/FeedReaderTest.php
@@ -282,6 +282,29 @@ class FeedReaderTest extends ContainerTestCase implements Controller
         $this->assertEquals('http://musikhusetaarhus.dk/media/2738/kultur-3.jpg', $event['original_image']);
     }
 
+    /**
+     * @group Tags
+     */
+    public function testReadFeedWithTags()
+    {
+        $feedConfiguration = $this->readFixture('feed-with-tags.yml');
+        $json = $this->readFixture('feed-with-tags.json');
+
+        $feed = $this->createFeed($feedConfiguration);
+
+        $reader = $this->container->get('feed_reader.json');
+        $reader
+            ->setController($this)
+            ->setFeed($feed);
+        $reader->read($json);
+
+        $this->assertEquals(2, count($this->events));
+        $event = $this->events[0];
+        $this->assertEquals(1, count($event['occurrences']));
+        $this->assertEquals('Musikhuset Aarhus', $event['occurrences'][0]['venue']);
+        $this->assertEquals('http://musikhusetaarhus.dk/media/2738/kultur-3.jpg', $event['original_image']);
+    }
+
     public function createEvent(array $data)
     {
         if (isset($data['image'])) {

--- a/tests/fixtures/AdminBundle/Service/FeedReaderTest/feed-with-tags.json
+++ b/tests/fixtures/AdminBundle/Service/FeedReaderTest/feed-with-tags.json
@@ -1,0 +1,68 @@
+{
+  "meta": {
+    "page": 1,
+    "itemsPerPage": 24,
+    "categoryFilter": "",
+    "category2Filter": "",
+    "query": "",
+    "startDate": "",
+    "endDate": "",
+    "totalPages": 8,
+    "totalResults": 179,
+    "randomize": false,
+    "ids": [],
+    "onlyBannerEvent": false
+  },
+  "events": [
+    {
+      "Id": 4855,
+      "Name": "Fotos fra egne scener",
+      "ExtraSearchWords": "",
+      "Image": "/media/2738/kultur-3.jpg",
+      "Categories": [
+        "Udstilling",
+        "Gratis",
+        "BabyCafe"
+      ],
+      "FutureEventDates": [
+        {
+          "Name": "Fotos fra egne scener",
+          "Price": "Gratis",
+          "EventSalesStatus": 0,
+          "StartDate": "/Date(1470992400000)/",
+          "EndDate": "/Date(1470996000000)/",
+          "EventVenueName": "Musikhuset Aarhus",
+          "EventVenueHall": "Strøget",
+          "EventStatusText": ""
+        }
+      ],
+      "PurchaseUrl": null,
+      "Url": "/arrangementer/fotos-fra-egne-scener/"
+    },
+    {
+      "Id": 4807,
+      "Name": "Sommer Chillout Aarhus",
+      "ExtraSearchWords": "",
+      "Image": "/media/2781/sca_web_landing.jpg",
+      "Categories": [
+        "Koncert",
+        "Gratis",
+        "BabyCafé"
+      ],
+      "FutureEventDates": [
+        {
+          "Name": "Sommer.Chillout.Aarhus",
+          "Price": "Gratis",
+          "EventSalesStatus": 0,
+          "StartDate": "/Date(1471075200000)/",
+          "EndDate": "/Date(1471075200000)/",
+          "EventVenueName": "Musikhuset Aarhus",
+          "EventVenueHall": "Amfiscenen",
+          "EventStatusText": ""
+        }
+      ],
+      "PurchaseUrl": null,
+      "Url": "/arrangementer/sommerchilloutaarhus/"
+    }
+  ]
+}

--- a/tests/fixtures/AdminBundle/Service/FeedReaderTest/feed-with-tags.yml
+++ b/tests/fixtures/AdminBundle/Service/FeedReaderTest/feed-with-tags.yml
@@ -1,0 +1,24 @@
+url: http://musikhusetaarhus.dk/umbraco/surface/Events/Index
+type: json
+# XPath, i.e. "data/events"
+root: events
+# Where to find occurrences inside an event
+occurrenceRoot: FutureEventDates
+# The event property containing a unique id
+# Mapping from feed event properties to API event properties
+baseUrl: http://musikhusetaarhus.dk/
+mapping:
+    id: Id
+    name: Name
+    url: Url
+    tags: Categories
+    image: Image
+    occurrences:
+        path: FutureEventDates
+        mapping:
+            startDate: StartDate
+            endDate: EndDate
+            venue: EventVenueName
+defaults:
+    tags: [ 'Musikhuset Aarhus' ]
+    occurrences.venue: 'Musikhuset Aarhus'


### PR DESCRIPTION
When importing feeds that contain tags with accents such as `babycafé` a database unique constraint can be triggered:
```
-- Error -----------------------------------------------------------------------
An exception occurred while executing 'INSERT INTO unknown_tag (name, slug, created_at, updated_at, tag_id) VALUES (?, ?, ?, ?, ?)' with params ["Strikke\/h\u00e6klecafe", "strikke-haeklecafe-1", "2020-09-16 10:39:05", "2020-09-16 10:39:05", null]:

SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'Strikke/hæklecafe' for key 'UNIQ_12F66F525E237E06' (feed #1)
--------------------------------------------------------------------------------
```

This is caused by the way both our `AdminBundle` and the `FabienPennequin/FPNTagBundle` detects if tags exists or should be created. Duplicate detection is done with `$missingNames = array_udiff($names, $loadedNames, 'strcasecmp');`. However to `array_udiff()` the tags `cafe` and `café` (accented e) are different but at the database level they are equal given our collation. This triggers the unique constraint because the `tagManager` tries to created both.

This PR fixes that by using a `SELECT EXISTS(SELECT * FROM tag WHERE name = :name)` query to determine if a tags exists. No comparison is done at the PHP level. This is requires more queries but is deemed the only realistic solution.

I have unsuccessfully attempted to update the test suite to cover this problem. The challenge here being that the feed importing tests does not touch the database. Hence the error is never triggered, and a failing test cannot be written. The Behat tests that does touch the database only test the API where the error is not present.

