### PR TITLE
EV-239: Update friendsofphp/php-cs-fixer and re-add check to actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,42 +98,41 @@ jobs:
             - name: Validate Doctrine schema
               run: SYMFONY_ENV=githubactions php bin/console doctrine:schema:validate
 
-# @TODO fix error on Github Actions Fatal error: Uncaught ErrorException: Use of undefined constant T_STRING - assumed 'T_STRING' (this will throw an Error in a future version of PHP) in /home/runner/work/event-database-api/event-database-api/vendor/friendsofphp/php-cs-fixer/src/FixerFactory.php:107
-#    php-cs-fixer:
-#        runs-on: ubuntu-latest
-#        strategy:
-#            fail-fast: false
-#            matrix:
-#                php: ["7.2"]
-#        name: PHP Coding Standards Fixer (PHP ${{ matrix.php }})
-#        steps:
-#            - name: Checkout
-#              uses: actions/checkout@v3
-#
-#            - name: Setup PHP, with composer and extensions
-#              uses: shivammathur/setup-php@v2
-#              with:
-#                  php-version: ${{ matrix.php}}
-#                  extensions: apcu, ctype, iconv, imagick, json, redis, soap, xmlreader, zip
-#                  coverage: none
-#                  tools: composer:v1
-#
-#            - name: Get composer cache directory
-#              id: composer-cache
-#              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-#
-#            - name: Cache dependencies
-#              uses: actions/cache@v3
-#              with:
-#                  path: ${{ steps.composer-cache.outputs.dir }}
-#                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-#                  restore-keys: ${{ runner.os }}-composer-
-#
-#            - name: '[dev] Composer install'
-#              run: composer install --no-interaction --prefer-dist
-#
-#            - name: Check Coding Standards
-#              run: symfony composer check-coding-standards
+    php-cs-fixer:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                php: ["7.2"]
+        name: PHP Coding Standards Fixer (PHP ${{ matrix.php }})
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup PHP, with composer and extensions
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php}}
+                  extensions: apcu, ctype, iconv, imagick, json, redis, soap, xmlreader, zip
+                  coverage: none
+                  tools: composer:v1
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache dependencies
+              uses: actions/cache@v3
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: '[dev] Composer install'
+              run: composer install --no-interaction --prefer-dist
+
+            - name: Check Coding Standards
+              run: symfony composer check-coding-standards
 
     phpunit:
         runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -132,7 +132,7 @@ jobs:
               run: composer install --no-interaction --prefer-dist
 
             - name: Check Coding Standards
-              run: symfony composer check-coding-standards
+              run: composer check-coding-standards
 
     phpunit:
         runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -152,6 +152,9 @@
         "patches": {
             "fpn/tag-bundle": {
                 "Prevent InvalidDefinitionException": "https://github.com/FabienPennequin/FPNTagBundle/compare/master...rimi-itk:Issue-39.patch"
+            },
+            "friendsofphp/php-cs-fixer": {
+                "Ensure PHP Extentions Installed": "./patches/php-cs-fixer.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -7105,51 +7105,55 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.14.2",
+            "version": "v2.19.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb"
+                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ff401e58261ffc5934a58f795b3f95b355e276cb",
-                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
+                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4",
-                "composer/xdebug-handler": "^1.2",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.2 || ^2.0",
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || ^7.0",
+                "php": "^5.6 || ^7.0 || ^8.0",
                 "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.17 || ^4.1.6",
-                "symfony/event-dispatcher": "^3.0 || ^4.0",
-                "symfony/filesystem": "^3.0 || ^4.0",
-                "symfony/finder": "^3.0 || ^4.0",
-                "symfony/options-resolver": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
                 "symfony/polyfill-php70": "^1.0",
                 "symfony/polyfill-php72": "^1.4",
-                "symfony/process": "^3.0 || ^4.0",
-                "symfony/stopwatch": "^3.0 || ^4.0"
+                "symfony/process": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
-                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.2",
+                "keradus/cli-executor": "^1.4",
                 "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.1",
+                "php-coveralls/php-coveralls": "^2.4.2",
                 "php-cs-fixer/accessible-object": "^1.0",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.0.1",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.0.1",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1",
-                "phpunitgoodpractices/traits": "^1.5.1",
-                "symfony/phpunit-bridge": "^4.0"
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
+                "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.5",
+                "phpunitgoodpractices/polyfill": "^1.5",
+                "phpunitgoodpractices/traits": "^1.9.1",
+                "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
+                "symfony/phpunit-bridge": "^5.2.1",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
-                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters.",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
                 "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
@@ -7158,6 +7162,11 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.19-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -7171,6 +7180,8 @@
                     "tests/Test/IntegrationCaseFactory.php",
                     "tests/Test/IntegrationCaseFactoryInterface.php",
                     "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/Test/IsIdenticalConstraint.php",
+                    "tests/Test/TokensWithObservedTransformers.php",
                     "tests/TestCase.php"
                 ]
             },
@@ -7180,16 +7191,22 @@
             ],
             "authors": [
                 {
-                    "name": "Dariusz Rumiński",
-                    "email": "dariusz.ruminski@gmail.com"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-02-17T17:44:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-15T17:17:55+00:00"
         },
         {
             "name": "fzaninotto/faker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd5e9c8ca1e223f2b0b07b0b8b70f687",
+    "content-hash": "4393b3721354a566c69479e4a7ffd93d",
     "packages": [
         {
             "name": "api-platform/core",
@@ -7165,6 +7165,9 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.19-dev"
+                },
+                "patches_applied": {
+                    "Ensure PHP Extentions Installed": "./patches/php-cs-fixer.patch"
                 }
             },
             "autoload": {

--- a/patches/php-cs-fixer.patch
+++ b/patches/php-cs-fixer.patch
@@ -1,0 +1,21 @@
+--- ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer	2021-11-15 18:17:55
++++ ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer-patched	2023-03-22 16:09:43
+@@ -50,6 +50,18 @@
+     }
+ }
+ 
++// Hack to avoid "PHP extension ext-json is missing from your system. Install or enable it."
++// error on Github Actions experienced with "json Enabled" in setup.
++// For install issues on MAcOS
++// @see https://github.com/cweagans/composer-patches/issues/423#issuecomment-1301026697
++foreach (['json', 'tokenizer'] as $extension) {
++    if (!extension_loaded($extension)) {
++        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
++        dl($prefix . $extension . '.' . PHP_SHLIB_SUFFIX);
++    }
++}
++unset($prefix);
++
+ foreach (['json', 'tokenizer'] as $extension) {
+     if (!extension_loaded($extension)) {
+         fwrite(STDERR, sprintf("PHP extension ext-%s is missing from your system. Install or enable it.\n", $extension));


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/EV-239

#### Description

* Update friendsofphp/php-cs-fixer 
* re-add check to actions
* [hack] patch cs-fixer to use `dl()` to load extention

Fixes this error were `cs-fixer` fails despite `json` extension installed:

<img width="884" alt="Screenshot 2023-03-22 at 16 19 25" src="https://user-images.githubusercontent.com/5631988/226952766-d5939e3b-7e39-497b-bb43-e0a2f53197af.png">


#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
