### PR TITLE
#687: Added "has feed" filter to events

### DIFF
--- a/app/config/api_filters.yml
+++ b/app/config/api_filters.yml
@@ -50,6 +50,11 @@ services:
               url: 'exact'
         tags: [{ name: 'api_platform.filter', id: 'event.search' }]
 
+    resource.event.exists_filter:
+        parent: 'api_platform.doctrine.orm.exists_filter'
+        arguments: [ { feed: '~' } ]
+        tags: [{ name: 'api_platform.filter' }]
+
     resource.event.search_owner_filter:
         class: AppBundle\Filter\OwnerFilter
         arguments:

--- a/app/config/api_filters.yml
+++ b/app/config/api_filters.yml
@@ -52,7 +52,8 @@ services:
 
     resource.event.exists_filter:
         parent: 'api_platform.doctrine.orm.exists_filter'
-        arguments: [ { feed: '~' } ]
+        arguments: 
+            - feed: '~'
         tags: [{ name: 'api_platform.filter' }]
 
     resource.event.search_owner_filter:

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -38,7 +38,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *     "jsonld_embed_context" = true,
  *     "normalization_context" = { "groups" = { "event_read" } },
  *     "denormalization_context" = { "groups" = { "event_write" } },
- *     "filters" = { "event.search", "event.search.date", "event.search.tag", "event.search.owner", "event.search.published", "event.search.access", "event.order", "event.order.default" },
+ *     "filters" = { "event.search", "event.search.date", "event.search.tag", "event.search.owner", "event.search.published", "event.search.access", "event.order", "event.order.default", "resource.event.exists_filter" },
  *     "validation_groups"={"event_write"}
  *   }
  * )
@@ -167,6 +167,7 @@ class Event extends Thing implements CustomTaggable, Blameable
     /**
      * @var Feed
      *
+     * @Groups({"event_read"})
      * @ORM\ManyToOne(targetEntity="AdminBundle\Entity\Feed")
      */
     private $feed;
@@ -174,6 +175,7 @@ class Event extends Thing implements CustomTaggable, Blameable
     /**
      * @var string
      *
+     * @Groups({"event_read"})
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     private $feedEventId;

--- a/web/api/api-spec-v1.json
+++ b/web/api/api-spec-v1.json
@@ -496,6 +496,12 @@
                         "type": "string"
                     },
                     {
+                        "name": "feed[exists]",
+                        "in": "query",
+                        "required": false,
+                        "type": "boolean"
+                    },
+                    {
                         "name": "page",
                         "in": "query",
                         "required": false,
@@ -1628,6 +1634,14 @@
                 },
                 "excerpt": {
                     "description": "Excerpt, i.e. short description, without any markup",
+                    "type": "string"
+                },
+                "feed": {
+                    "readOnly": true,
+                    "type": "string"
+                },
+                "feedEventId": {
+                    "readOnly": true,
                     "type": "string"
                 },
                 "tags": {


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/687

#### Description

- Add `feed[exists]` filter to events endpoint. Needed to migrate non-feed events to new event db

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
